### PR TITLE
Update empty and full.dcignore.js to point to Snyk documentation

### DIFF
--- a/empty.dcignore.js
+++ b/empty.dcignore.js
@@ -1,4 +1,4 @@
 exports.file = `# Write glob rules for ignored files.
-# Check syntax on https://deepcode.freshdesk.com/support/solutions/articles/60000531055-how-can-i-ignore-files-or-directories-
+# For more information, see https://docs.snyk.io/scm-ide-and-ci-cd-integrations/snyk-ide-plugins-and-extensions/visual-studio-code-extension/create-a-.dcignore-file
 # Check examples on https://github.com/github/gitignore
 `;

--- a/full.dcignore.js
+++ b/full.dcignore.js
@@ -1,5 +1,5 @@
 exports.file = `# Write glob rules for ignored files.
-# Check syntax on https://deepcode.freshdesk.com/support/solutions/articles/60000531055-how-can-i-ignore-files-or-directories-
+# For more information, see https://docs.snyk.io/scm-ide-and-ci-cd-integrations/snyk-ide-plugins-and-extensions/visual-studio-code-extension/create-a-.dcignore-file
 # Check examples on https://github.com/github/gitignore
 
 # Hidden directories
@@ -723,7 +723,8 @@ dist/
 EIFGENs
 
 # macOS
-Icon
+Icon
+
 Network Trash Folder
 Temporary Items
 


### PR DESCRIPTION
This template is used by the Snyk extension and should therefore refer to the proper documentation.